### PR TITLE
added mergeConflicts file in the github action

### DIFF
--- a/.github/workflows/Check-for-merge-conflicts.yml
+++ b/.github/workflows/Check-for-merge-conflicts.yml
@@ -1,0 +1,13 @@
+name: 'Check for merge conflicts'
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'has merge conflicts'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The typical use case is to run this action post merge (e.g. push to master) to quickly see which other PRs are now in conflict.