### PR TITLE
fix: remove git add from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,10 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.{js,jsx}/": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Closes #145

Remove `git add` instructions from `package.json` file to avoid warning.